### PR TITLE
docs: add Create Eth App in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ A list of links to articles, tutorials and papers that are helpful for people de
   12. [Youtube channel - detailed course on solidity language](https://www.youtube.com/channel/UCaWes1eWQ9TbzA695gl_PtA)
   13. [Web developer, welcome to Ethereum](http://cfd.net.au/article/web-developer-welcome-ethereum-tue-10242017-0307.html)
   14. [React & Ethereum getting started](https://medium.com/gitconnected/https-medium-com-zubairnahmed-react-ethereum-getting-started-with-the-minimum-toolset-required-part-1-of-4-9562efa23d18)
-  15. [Designing the architecture for your ethereum application](https://blog.zeppelin.solutions/designing-the-architecture-for-your-ethereum-application-9cec086f8317)
-  16. [Crypto Zombies](https://cryptozombies.io/)
-  17. [Solidity idiosyncrasies](https://github.com/miguelmota/solidity-idiosyncrasies)
-  18. [Ethereum Development with Go](https://goethereumbook.org/)
+  15. [Build Your Ethereum Project with Create Eth App](https://www.paulrberg.com/create-eth-app-intro/)
+  16. [Designing the architecture for your ethereum application](https://blog.zeppelin.solutions/designing-the-architecture-for-your-ethereum-application-9cec086f8317)
+  17. [Crypto Zombies](https://cryptozombies.io/)
+  18. [Solidity idiosyncrasies](https://github.com/miguelmota/solidity-idiosyncrasies)
+  19. [Ethereum Development with Go](https://goethereumbook.org/)
 
 ## Security
   1. [Solidity docs security considerations](https://solidity.readthedocs.io/en/develop/security-considerations.html)


### PR DESCRIPTION
I added a link to the [blog post][1] that shows how [create-eth-app][2] can be used to build an Ethereum-powered frontend app.

[1]: https://paulrberg.com/create-eth-app-intro/ 
[2]: https://github.com/paulrberg/create-eth-app